### PR TITLE
abstract page header away to BasePage for cleaner code in most pages

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -16,11 +16,7 @@ MainView {
 
         property bool darkMode: false
 
-        onDarkModeChanged: if (darkMode){
-                                Theme.name = "Ubuntu.Components.Themes.SuruDark"
-                            }else{
-                                Theme.name = "Ubuntu.Components.Themes.Ambiance"
-                            }
+        onDarkModeChanged: Theme.name = darkMode ? "Ubuntu.Components.Themes.SuruDark" : "Ubuntu.Components.Themes.Ambiance"
     }
 
     width: units.gu(45)

--- a/qml/pages/AccountsPage.qml
+++ b/qml/pages/AccountsPage.qml
@@ -6,10 +6,8 @@ PageBase {
 
     showBottomMenu : false
 
-    header : PageHeader {
-                id: accountsPageHeader
-                title: i18n.tr('Accounts')
-            }
+    pageHeader.title: i18n.tr('Accounts')
+
     Button{
         id: addAccountsButton
 
@@ -21,7 +19,7 @@ PageBase {
 
         anchors{
             horizontalCenter: parent.horizontalCenter
-            top: accountsPageHeader.bottom
+            top: pageHeader.bottom
             topMargin: units.gu(2)
         }
     }

--- a/qml/pages/AddAccountPage.qml
+++ b/qml/pages/AddAccountPage.qml
@@ -6,15 +6,13 @@ PageBase {
 
     showBottomMenu : false
 
-    header : PageHeader {
-                id: addAccountPageHeader
-                title: i18n.tr('Add Account')
-            }
+    pageHeader.title: i18n.tr('Add Account')
+
     Column{
         id: addAccountColumn
 
         anchors {
-            topMargin: addAccountPageHeader.height
+            topMargin: pageHeader.height
             fill: parent
         }
 

--- a/qml/pages/HomePage.qml
+++ b/qml/pages/HomePage.qml
@@ -10,42 +10,41 @@ PageBase {
     property var streamingProvider
     property var pageStack
 
-    header: PageHeader {
-                id: homePageHeader
+    pageHeader {
 
-                title: i18n.tr('Stream')
-                subtitle: streamingProvider.name
+        title: i18n.tr('Stream')
+        subtitle: streamingProvider.name
 
-                extension: Sections {
-                    id: homePageHeaderSections
-                    actions: [ 
-                        Action {
-                            text: 'Playlists'
-                        },
-                        Action {
-                            text: 'Artists'
-                        },
-                        Action {
-                            text: 'Albums'
-                        },
-                        Action {
-                            text: 'Podcasts'
-                        }
-                    ]
-
-                    onSelectedIndexChanged: homePageTabView.currentIndex = selectedIndex
+        extension: Sections {
+            id: homePageHeaderSections
+            actions: [ 
+                Action {
+                    text: 'Playlists'
+                },
+                Action {
+                    text: 'Artists'
+                },
+                Action {
+                    text: 'Albums'
+                },
+                Action {
+                    text: 'Podcasts'
                 }
+            ]
 
-                trailingActionBar {
-                    actions: [
-                        Action {
-                            iconName: "settings"
-                            text: "Settings"
-                            onTriggered: mainStack.push( Qt.resolvedUrl("SettingsPage.qml"))
-                        }
-                    ]
+            onSelectedIndexChanged: homePageTabView.currentIndex = selectedIndex
+        }
+
+        trailingActionBar {
+            actions: [
+                Action {
+                    iconName: "settings"
+                    text: "Settings"
+                    onTriggered: mainStack.push( Qt.resolvedUrl("SettingsPage.qml"))
                 }
-            }
+            ]
+        }
+    }
 
 
     VisualItemModel {
@@ -120,7 +119,7 @@ PageBase {
 
         anchors {
             fill: parent
-            topMargin: homePageHeader.height
+            topMargin: pageHeader.height
         } 
 
         model: homePageTabs

--- a/qml/pages/PageBase.qml
+++ b/qml/pages/PageBase.qml
@@ -4,5 +4,10 @@ import Ubuntu.Components 1.3
 Page {
 
     property bool showBottomMenu: true
+    property alias pageHeader: _header
+
+    header: PageHeader {
+        id: _header
+    }
 
 }

--- a/qml/pages/PlayerPage.qml
+++ b/qml/pages/PlayerPage.qml
@@ -16,10 +16,7 @@ PageBase {
     property string albumart
     property alias player: player
 
-    header: PageHeader {
-                id: playerPageHeader
-                title: i18n.tr('Now playing')
-            }
+    pageHeader.title: i18n.tr('Now playing')
 
     Audio {
         id: player

--- a/qml/pages/PlaylistPage.qml
+++ b/qml/pages/PlaylistPage.qml
@@ -7,21 +7,19 @@ import ".."
 PageBase {
     id: playlistPage
 
-    property alias playlistTitle : header.title
+    property string playlistTitle 
     property var provider
 
     anchors.fill: parent
 
-    header: PageHeader {
-                id: header
-            }
-            
+    pageHeader.title: playlistTitle
+
     ListView {
         id: listview
 
         anchors {
             fill: parent
-            topMargin: header.height
+            topMargin: pageHeader.height
         }
 
         model: provider.playlistModel

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -6,15 +6,13 @@ PageBase {
 
     showBottomMenu : false
 
-    header : PageHeader {
-                id: settingsPageHeader
-                title: i18n.tr('Settings.')
-            }
+    pageHeader.title: i18n.tr('Settings')
+
     Column{
         id: tabSettingsColumn
         
         anchors {
-            topMargin: settingsPageHeader.height
+            topMargin: pageHeader.height
             fill: parent
         }
 

--- a/qml/pages/SubsonicLoginPage.qml
+++ b/qml/pages/SubsonicLoginPage.qml
@@ -9,10 +9,7 @@ PageBase {
 
     showBottomMenu: false
 
-    header: PageHeader {
-                id: loginPageHeader
-                title: "Subsonic"
-            }
+    pageHeader.title: "Subsonic"
 
     Component.onCompleted: {
         serverurlField.text = provider.settings.serverurl
@@ -28,7 +25,7 @@ PageBase {
 
         anchors {
             horizontalCenter: parent.horizontalCenter
-            top: loginPageHeader.bottom
+            top: pageHeader.bottom
             topMargin: units.gu(2)
         }
 
@@ -126,6 +123,7 @@ PageBase {
                                         provider.settings.serverurl = serverurlField.text
                                         provider.settings.username = usernameField.text
                                         provider.settings.password = passwordField.text
+                                        
                                         mainStack.clear()
                                         mainStack.push( Qt.resolvedUrl("HomePage.qml"),{
                                             streamingProvider:  provider,

--- a/qml/pages/WelcomePage.qml
+++ b/qml/pages/WelcomePage.qml
@@ -9,10 +9,7 @@ PageBase {
 
     showBottomMenu: false
 
-    header: PageHeader {
-                id: welcomePageHeader
-                title: "Stream"
-            }
+    pageHeader.title: "Stream"
 
     UbuntuShape {
         id: appIcon
@@ -22,7 +19,7 @@ PageBase {
 
         anchors {
             horizontalCenter: parent.horizontalCenter
-            top: welcomePageHeader.bottom
+            top: pageHeader.bottom
             topMargin: units.gu(2)
         }
 


### PR DESCRIPTION
Introduce pageHeader property in BasePage
Change all Pages to use the newly inherited pageHeader property